### PR TITLE
Add CI workflow to build and test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Debug Build on ubuntu-${{ matrix.release }}
+
+on:
+  pull_request:
+    branches: [ master ]
+    paths-ignore:
+      - '**.md'
+      - LICENSE
+
+jobs:
+  build-ubuntu:
+    runs-on: ubuntu-${{ matrix.release }}
+    strategy:
+      matrix:
+        version: [11, 12, 13, 14, 15]
+        # We run on ubuntu-latest as well to capture when a new
+        # version is added.
+        release: [18.04, 20.04, 22.04, latest]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup PGDG
+      run: |
+        sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+        wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+        sudo apt-get update
+    - name: Install PostgreSQL
+      run: sudo apt-get -y install cmake postgresql postgresql-server-dev-all postgresql-server-dev-${{ matrix.version }}
+    - name: Check that tools were successfully installed
+      run: |
+        pg_config
+        ls `pg_config --includedir-server`
+    - name: Build extensions
+      run: make
+    - name: Install extensions
+      run: make install
+    - name: Run tests
+      run: make installcheck


### PR DESCRIPTION
Build and test the extension on all actively maintained versions of PostgreSQL and Ubuntu. We use the packages distribued from PGDG.

PostgreSQL versions supported are 11, 12, 13, and 14.

Ubuntu versions supported are 18.04, 20.04, 22.04 (note that 18.04 is deprecated and might be removed in the future, but for now we test it).