### PR TITLE
Fix parse state and segfault because of a missing transaction start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 EXTENSION = influx
 DATA = influx--0.3.sql
 MODULE_big = influx
-OBJS = influx.o worker.o network.o parser.o cache.o metric.o
+OBJS = influx.o worker.o network.o ingest.o cache.o metric.o
 
 REGRESS = parse worker inval
 REGRESS_OPTS += --load-extension=influx
@@ -25,7 +25,7 @@ PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 
 cache.o: cache.c cache.h
-influx.o: influx.c influx.h parser.h
+influx.o: influx.c influx.h ingest.h
 network.o: network.c network.h
-parser.o: parser.c parser.h
-worker.o: worker.c worker.h cache.h influx.h parser.h network.h
+ingest.o: ingest.c ingest.h
+worker.o: worker.c worker.h cache.h influx.h ingest.h network.h

--- a/influx.h
+++ b/influx.h
@@ -27,9 +27,9 @@
 
 #include <stdbool.h>
 
-#include "parser.h"
+#include "ingest.h"
 
-ParseState *ParseInfluxSetup(char *buffer);
+IngestState *ParseInfluxSetup(char *buffer);
 Jsonb *BuildJsonObject(List *items);
 
 #endif /* INFLUX_H_ */

--- a/ingest.h
+++ b/ingest.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef PARSER_H_
-#define PARSER_H_
+#ifndef INGEST_H_
+#define INGEST_H_
 
 #include <postgres.h>
 
@@ -28,22 +28,23 @@
 #include "metric.h"
 
 /**
- * Parser state.
+ * Ingest parser state.
  *
  * @note All pointers in the parser state will point into the line
  * buffer.
  */
-typedef struct ParseState {
-  char *start; /**< Start of line buffer */
+typedef struct IngestState {
+  /** Start of line buffer */
+  char *start;
 
   /** Current read position of line buffer  */
   char *current;
 
   /** Metric resulting from the parse. */
   Metric metric;
-} ParseState;
+} IngestState;
 
-void ParseStateInit(ParseState *state, char *line);
-bool ReadNextLine(ParseState *state);
+void IngestStateInit(IngestState *state, char *line);
+bool IngestReadNextLine(IngestState *state);
 
-#endif /* PARSER_H_ */
+#endif /* INGEST_H_ */

--- a/worker.c
+++ b/worker.c
@@ -64,13 +64,13 @@ static volatile sig_atomic_t ShutdownWorker = false;
  * Process one packet of lines.
  */
 static void ProcessPacket(char *buffer, size_t bytes, Oid nspid) {
-  ParseState *state;
+  IngestState *state;
 
   buffer[bytes] = '\0';
   state = ParseInfluxSetup(buffer);
 
   while (true) {
-    if (!ReadNextLine(state))
+    if (!IngestReadNextLine(state))
       return;
     MetricInsert(&state->metric, nspid);
   }

--- a/worker.c
+++ b/worker.c
@@ -158,6 +158,12 @@ void WorkerMain(Datum arg) {
                 errdetail("service=%s, database_id=%u, namespace_id=%u",
                           args->service, database_id, args->namespace_id)));
 
+  /* We need to start a transaction first because none is started and
+     SPI_connect_ext might use TopTransactionContext, which is set by
+     this function. The SPI_commit below will automatically start a
+     new one. */
+  StartTransactionCommand();
+
   /* This is the same approach as used in pgstats.c: We read the
      packets in two loops. One outer that will block when there is no
      data received, and one inner loop that will read packets as long
@@ -180,7 +186,6 @@ void WorkerMain(Datum arg) {
        sure that it does not change while we are updating it. */
     if ((err = SPI_connect_ext(SPI_OPT_NONATOMIC)) != SPI_OK_CONNECT)
       elog(ERROR, "SPI_connect failed: %s", SPI_result_code_string(err));
-    SPI_start_transaction();
     PushActiveSnapshot(GetTransactionSnapshot());
 
     pgstat_report_activity(STATE_RUNNING, "processing incoming packets");


### PR DESCRIPTION
This PR consists of two commits:

    Start a transaction when starting the worker
    
    There is no transaction started when connecting to the SPI and
    `SPI_start_transaction` is a no-op. Each `SPI_commit` will automatically
    start a new transaction, we wo do not need to start a transaction in the
    loop.
    
    Fixes #2

----

    Rename ParseState to avoid collision
    
    PostgreSQL has a `ParseState` as well, so we end up with a collision
    causing the compile to fail. We rename this to `IngestState` to avoid
    collisions.
