### PR TITLE
Use SO_REUSEPORT for UDP sockets

### DIFF
--- a/network.c
+++ b/network.c
@@ -32,17 +32,39 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-static int SetNonblocking(int fd, const struct sockaddr* addr,
-                          socklen_t addrlen) {
-  if (!pg_set_noblock(fd))
+/*
+ * Configure UDP receive socket.
+ *
+ * We set it to non-blocking to be able to react to PostgreSQL
+ * interrupts and process them and we use SO_REUSEPORT to allow
+ * several UDP workers to be connected to the same socket and read and
+ * process the packets.
+ */
+static int ConfigUdpRecvSocket(int fd, const struct sockaddr* addr,
+                               socklen_t addrlen) {
+  if (!pg_set_noblock(fd)) {
     ereport(LOG, (errcode_for_socket_access(),
                   errmsg("could not set socket to nonblocking mode: %m")));
-  return -1;
+    return STATUS_ERROR;
+  }
+
+  return STATUS_OK;
+}
+
+static int SetupUdpRecvSocket(int fd, const struct sockaddr* addr,
+                              socklen_t addrlen) {
+  int optval = 1;
+  if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval)) < 0) {
+    ereport(LOG, (errmsg("%s(%s) failed: %m", "setsockopt", "SO_REUSEPORT")));
+    return STATUS_ERROR;
+  }
+
+  return bind(fd, addr, addrlen);
 }
 
 struct SocketMethod UdpRecvSocket = {
-    .setup = bind,
-    .config = SetNonblocking,
+    .setup = SetupUdpRecvSocket,
+    .config = ConfigUdpRecvSocket,
     .name = "bind",
     .socktype = SOCK_DGRAM,
     .flags = AI_PASSIVE,
@@ -106,14 +128,14 @@ int CreateSocket(const char* hostname, const char* service,
   pg_freeaddrinfo_all(hints.ai_family, addrs);
 
   if (method->config == NULL ||
-      (*method->config)(fd, addr->ai_addr, addr->ai_addrlen)) {
+      (*method->config)(fd, addr->ai_addr, addr->ai_addrlen) == STATUS_OK) {
     if (paddr) {
       Assert(addr->ai_addrlen <= addrlen);
       memcpy(paddr, addr->ai_addr, addr->ai_addrlen);
     }
     return fd;
   }
-  return -1;
+  return STATUS_ERROR;
 }
 
 PG_FUNCTION_INFO_V1(send_packet);


### PR DESCRIPTION
To allow multiple workers to attach to a UDP address, we use `SO_REUSEPORT`. Each worker will then read and process a single packet from the socket and insert it into the database.

Fixes #6