### PR TITLE
Add support for spawning background workers on startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.o
 *.so
-results/**
+
+/results/**
+/.cache

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,8 @@ PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 
 cache.o: cache.c cache.h
-influx.o: influx.c influx.h ingest.h
+influx.o: influx.c influx.h ingest.h metric.h worker.h
+ingest.o: ingest.c ingest.h metric.h
+metric.o: metric.c metric.h cache.h
 network.o: network.c network.h
-ingest.o: ingest.c ingest.h
-worker.o: worker.c worker.h cache.h influx.h ingest.h network.h
+worker.o: worker.c worker.h cache.h influx.h ingest.h metric.h network.h

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ including its intended use.
 
 ## Documentation
 
-- [Reference documentation](docs/reference.md)
+- [Documentation](docs/index.md)
 
 ## Building and Installing
 

--- a/README.md
+++ b/README.md
@@ -87,3 +87,10 @@ STRING_CHAR = ? any character except quote or backslash ?;
 LETTER = ? any letter ?;
 DIGIT = ? any digit ?;
 ```
+
+## InfluxDB Ports
+
+| Port | Protocol | Description                                           |
+|:-----|:---------|:------------------------------------------------------|
+| 8089 | UDP      | The default port that runs the UDP service.           |
+| 8086 | HTTP/TCP | The default port that runs the InfluxDB HTTP service. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,4 @@
+# Reference documentation for `pg_influx`
+
+1. [Function and Procedure Reference](procedures.md)
+1. [Configuration Options Reference](options.md)

--- a/docs/options.md
+++ b/docs/options.md
@@ -1,0 +1,25 @@
+# Configuration Options Reference for `pg_influx`
+
+To load the extension on startup, add it to `shared_preload_libraries`
+in the configuration file. In addition, the following options are
+supported.
+
+<dl>
+  <dt><code>influx.workers</code></dt>
+  <dd>Number of workers to spawn when starting up. Defaults to 4.</dd>
+
+  <dt><code>influx.service</code></dt>
+  <dd>Service or port to listen on. If it is a service name, it will
+  be looked up in services. Defaults to 8089, which is the default
+  InfluxDB port for UDP.</dd>
+  
+  <dt><code>influx.database</code></dt>
+  <dd>Database name for the worker to connect to.</dd>
+
+  <dt><code>influx.role</code></dt>
+  <dd>Role name for the worker to connect to the database as. Defaults
+  to use the superuser.</dd>
+
+  <dt><code>influx.schema</code></dt>
+  <dd>Schema where the metric tables are located.</dd>
+</dl>

--- a/docs/procedures.md
+++ b/docs/procedures.md
@@ -2,6 +2,8 @@
 
 ## Function `worker_launch`
 
+Launch a new background worker.
+
 ### Parameters
 
 |      Name | Type           | Description                         |
@@ -26,6 +28,8 @@ with [`pg_terminate_backend`][1] to terminate the backend.
 [1]: https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-ADMIN-SIGNAL-TABLE
 
 ## Procedure `send_packet`
+
+Send a UDP packet to a network address.
 
 ### Parameters
 

--- a/influx.c
+++ b/influx.c
@@ -19,10 +19,15 @@
 #include <postgres.h>
 #include <fmgr.h>
 
+#include <catalog/namespace.h>
 #include <catalog/pg_type.h>
 #include <executor/spi.h>
 #include <funcapi.h>
+#include <miscadmin.h>
+#include <postmaster/bgworker.h>
+#include <utils/acl.h>
 #include <utils/builtins.h>
+#include <utils/guc.h>
 #include <utils/int8.h>
 #include <utils/jsonb.h>
 #include <utils/timestamp.h>
@@ -31,14 +36,30 @@
 #include <string.h>
 
 #include "ingest.h"
+#include "worker.h"
 
 PG_MODULE_MAGIC;
 
 PG_FUNCTION_INFO_V1(parse_influx);
 
-/**
- * Parser state setup.
- */
+void _PG_init(void);
+
+/** Number of Influx protocol workers. */
+static int InfluxWorkersCount;
+
+/** Service name to listen on. */
+static char *InfluxServiceName;
+
+/** Schema name to use for metrics. */
+static char *InfluxSchemaName;
+
+/** Database name to work with. */
+static char *InfluxDatabaseName;
+
+/** Role name to use when connecting to the database. */
+static char *InfluxRoleName;
+
+/** Parser state setup. */
 IngestState *ParseInfluxSetup(char *buffer) {
   IngestState *state = palloc(sizeof(IngestState));
   IngestStateInit(state, buffer);
@@ -122,4 +143,76 @@ Datum parse_influx(PG_FUNCTION_ARGS) {
     SRF_RETURN_DONE(funcctx);
 
   SRF_RETURN_NEXT(funcctx, PointerGetDatum(HeapTupleGetDatum(tuple)));
+}
+
+static void StartBackgroundWorkers(const char *database_name,
+                                   const char *schema_name,
+                                   const char *role_name,
+                                   const char *service_name, int worker_count) {
+  MemoryContext oldcontext = MemoryContextSwitchTo(TopMemoryContext);
+  WorkerArgs args = {.namespace = schema_name ? pstrdup(schema_name) : NULL,
+                     .database = database_name ? pstrdup(database_name) : NULL,
+                     .role = role_name ? pstrdup(role_name) : NULL,
+                     .service = service_name ? pstrdup(service_name) : NULL};
+  int i;
+  BackgroundWorker worker;
+  elog(LOG, "starting influx workers");
+
+  InfluxWorkerInit(&worker, &args);
+  elog(LOG, "memory allocated in %s memory context",
+       CurrentMemoryContext->name);
+  for (i = 0; i < worker_count; i++)
+    RegisterBackgroundWorker(&worker);
+  elog(LOG, "background workers started");
+  MemoryContextSwitchTo(oldcontext);
+}
+
+void _PG_init(void) {
+  DefineCustomIntVariable("influx.workers",     /* option name */
+                          "Number of workers.", /* short descriptor */
+                          "Number of workers to spawn when starting up"
+                          "the server.",       /* long description */
+                          &InfluxWorkersCount, /* value address */
+                          4,                   /* boot value */
+                          0,                   /* min value */
+                          20,                  /* max value */
+                          PGC_SIGHUP,          /* option context */
+                          0,                   /* option flags */
+                          NULL,                /* check hook */
+                          NULL,                /* assign hook */
+                          NULL);               /* show hook */
+
+  if (!process_shared_preload_libraries_in_progress)
+    return;
+
+  /* Right now we have only UDP supported, so we use 8089. If we decide to
+   * support more protocols, we should dynamically pick the default based on the
+   * protocol. */
+  DefineCustomStringVariable(
+      "influx.service", "Service name.",
+      "Service name to listen on, or port number. If it is a service name, it"
+      " will be looked up.If it is a port, it will be used as it is.",
+      &InfluxServiceName, "8089", PGC_POSTMASTER, 0, NULL, NULL, NULL);
+  DefineCustomStringVariable(
+      "influx.database", "Database name.", "Database name to connect to.",
+      &InfluxDatabaseName, NULL, PGC_POSTMASTER, 0, NULL, NULL, NULL);
+  DefineCustomStringVariable(
+      "influx.role", "Role name.",
+      "Role name to use when connecting to the database. Default is to"
+      " connect as superuser.",
+      &InfluxRoleName, NULL, PGC_POSTMASTER, 0, NULL, NULL, NULL);
+  DefineCustomStringVariable(
+      "influx.schema", "Schema name.",
+      "Schema name to use for the workers. This is where the measurement"
+      " tables should be placed.",
+      &InfluxSchemaName, NULL, PGC_POSTMASTER, 0, NULL, NULL, NULL);
+
+  elog(LOG,
+       "InfluxDatabaseName: %s, InfluxSchemaName: %s, InfluxServiceName: %s, "
+       "InfluxRoleName: %s, InfluxWorkersCount: %d",
+       InfluxDatabaseName, InfluxSchemaName, InfluxServiceName, InfluxRoleName,
+       InfluxWorkersCount);
+
+  StartBackgroundWorkers(InfluxDatabaseName, InfluxSchemaName, InfluxRoleName,
+                         InfluxServiceName, InfluxWorkersCount);
 }

--- a/network.c
+++ b/network.c
@@ -77,13 +77,24 @@ struct SocketMethod UdpSendSocket = {
     .flags = 0,
 };
 
+int SocketPort(struct sockaddr* addr, socklen_t addrlen) {
+  switch (addr->sa_family) {
+    case AF_INET:
+      return ((struct sockaddr_in*)addr)->sin_port;
+    case AF_INET6:
+      return ((struct sockaddr_in6*)addr)->sin6_port;
+    default:
+      return -1;
+  }
+}
+
 /**
  * Create a new socket for communication.
  *
  * Lookup the address and service given and try to connect or bind it
  * to make sure that it is usable.
  *
- * @param paddr Save the address in this location.
+ * @param paddr Save the address in this location, if non-NULL.
  */
 int CreateSocket(const char* hostname, const char* service,
                  const struct SocketMethod* method, struct sockaddr* paddr,

--- a/network.h
+++ b/network.h
@@ -39,5 +39,6 @@ extern struct SocketMethod UdpSendSocket;
 extern int CreateSocket(const char* hostname, const char* service,
                         const struct SocketMethod*, struct sockaddr* addr,
                         socklen_t addrlen);
+extern int SocketPort(struct sockaddr* addr, socklen_t addrlen);
 
 #endif /* NETWORK_H_ */

--- a/worker.h
+++ b/worker.h
@@ -19,7 +19,19 @@
 
 #include <postgres.h>
 
-#define BGW_LIBRARY_NAME "influx"
-#define BGW_FUNCTION_NAME "WorkerMain"
+#include <postmaster/bgworker.h>
+
+#define INFLUX_LIBRARY_NAME "influx"
+#define INFLUX_FUNCTION_NAME "InfluxWorkerMain"
+
+typedef struct WorkerArgs {
+  const char *role;
+  const char *namespace;
+  const char *database;
+  const char *service;
+} WorkerArgs;
+
+void InfluxWorkerInit(BackgroundWorker *worker, WorkerArgs *args);
+void InfluxWorkerMain(Datum dbid) pg_attribute_noreturn();
 
 #endif /* WORKER_H_ */


### PR DESCRIPTION
This commit adds support for spawning workers automatically on server startup.
To support this, the extension needs to be loaded using
`shared_preload_libraries` in the configuration file. The options added in this
commit are:

`influx.workers`: The number of workers to spawn.

`influx.service`: The service name or port where the workers will listen. Defaults to port 8089.

`influx.database`:  The name of the database where the workers will connect.

`influx.schema`: The schema name where the workers will write the metrics.

`influx.role`: The role used when writing to the tables. Defaults to the superuser.

Closes #9
