### PR TITLE
Fix build for PostgreSQL 15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build and Test PostgreSQL ${{ matrix.version }}
+name: Build and Test
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [13, 14]
+        version: [13, 14, 15]
     container:
       image: postgres:${{ matrix.version }}
     steps:

--- a/influx.c
+++ b/influx.c
@@ -28,7 +28,6 @@
 #include <utils/acl.h>
 #include <utils/builtins.h>
 #include <utils/guc.h>
-#include <utils/int8.h>
 #include <utils/jsonb.h>
 #include <utils/timestamp.h>
 

--- a/worker.c
+++ b/worker.c
@@ -33,7 +33,9 @@
 #include <utils/builtins.h>
 #include <utils/elog.h>
 #include <utils/guc.h>
+#if PG_VERSION_NUM < 150000
 #include <utils/int8.h>
+#endif
 #include <utils/jsonb.h>
 #include <utils/lsyscache.h>
 #include <utils/rel.h>


### PR DESCRIPTION
PostgreSQL 15 removes `scanint8()` from the code in favor of using `strtoi64()` and `pg_strtoint64()` so this commit will switch to using them for PostgreSQL 15 and later.

See https://github.com/postgres/postgres/commit/cfc7191dfea330dd7a71e940d59de78129bb6175