### PR TITLE
ci: add release configuration

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,22 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - "CI/CD"
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking-change
+    - title: New Features
+      labels:
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Build and Packaging Improvements
+      labels:
+        - packaging
+        - build
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
Add release configuration in `release.yml`. Add sections for features, bugs,
breaking changes, and other changes. Anything tagged with `ignore-for-release`
will not be added to the release notes, and neither will anything tagged
`CI/CD`.