### PR TITLE
ci: use node16 for github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         apt-get update
         apt-get install -qy make gcc postgresql-server-dev-${{ matrix.version }} postgresql-client-${{ matrix.version }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build extensions
       run: make
     - name: Install extensions


### PR DESCRIPTION
GitHub is switching to use node16 for GitHub actions, so updating to `checkout@v3`.

See https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/