### PR TITLE
Non stop error

### DIFF
--- a/expected/worker.out
+++ b/expected/worker.out
@@ -4,10 +4,7 @@ CREATE TABLE db_worker.disk(_time timestamptz, host text, device text, _tags jso
 CREATE TABLE db_worker.system(_time timestamp, host text, uptime int, _tags jsonb, _fields jsonb);
 \set VERBOSITY terse
 \x on
-SELECT pg_sleep(1) FROM worker_launch('db_worker', 4711::text);
--[ RECORD 1 ]
-pg_sleep | 
-
+SELECT pg_sleep(1), pid worker_pid FROM worker_launch('db_worker', 4711::text) pid \gset
 CALL send_packet('cpu,cpu=cpu0,host=fury usage_system=2.0408163264927324,usage_user=2.0408163264927324 1574753954000000000', 4711::text);
 CALL send_packet('cpu,cpu=cpu1,host=fury usage_system=3.921568627286635,usage_user=3.9215686274649673 1574753954000000000', 4711::text);
 CALL send_packet('disk,device=nvme0n1p2,fstype=ext4,host=fury,mode=rw,path=/ free=912578965504i,total=1006530654208i,used=42751348736i,used_percent=4.475033200428718 1574753954000000000', 4711::text);
@@ -62,6 +59,20 @@ host    | fury
 uptime  | 
 _tags   | {}
 _fields | {"uptime_format": "7 days,  0:47"}
+
+SELECT count(*) FROM pg_stat_activity WHERE pid = :worker_pid;
+-[ RECORD 1 ]
+count | 1
+
+-- Syntax error, but the worker should not stop
+CALL send_packet('system,host=fury', 4711::text);
+SELECT pg_sleep(1);
+-[ RECORD 1 ]
+pg_sleep | 
+
+SELECT count(*) FROM pg_stat_activity WHERE pid = :worker_pid;
+-[ RECORD 1 ]
+count | 1
 
 SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE backend_type like '%Influx%';
 -[ RECORD 1 ]--------+--

--- a/metric.c
+++ b/metric.c
@@ -219,18 +219,16 @@ void MetricInsert(Metric *metric, int nspid) {
   AttInMetadata *attinmeta;
   int err, i, natts;
 
-  /* Get tuple descriptor for metric table and parse all the data
-   * into values array. To do this, we open the table for access and
-   * keep it open until the end of the transaction. Otherwise, the
-   * table definition can change before we've had a chance to insert
-   * the data. */
-  relid = get_relname_relid(metric->name, nspid);
-
   /* If the table does not exist, we just skip the line silently. */
   relid = get_relname_relid(metric->name, nspid);
   if (relid == InvalidOid)
     return;
 
+  /* Get tuple descriptor for metric table and parse all the data
+   * into values array. To do this, we open the table for access and
+   * keep it open until the end of the transaction. Otherwise, the
+   * table definition can change before we've had a chance to insert
+   * the data. */
   rel = table_open(relid, AccessShareLock);
   attinmeta = TupleDescGetAttInMetadata(RelationGetDescr(rel));
   natts = attinmeta->tupdesc->natts;

--- a/worker.c
+++ b/worker.c
@@ -72,7 +72,13 @@ static void ProcessPacket(char *buffer, size_t bytes, Oid nspid) {
   state = ParseInfluxSetup(buffer);
 
   while (true) {
-    if (!IngestReadNextLine(state))
+    bool result;
+    PG_TRY();
+    { result = IngestReadNextLine(state); }
+    PG_CATCH();
+    { result = false; }
+    PG_END_TRY();
+    if (!result)
       return;
     MetricInsert(&state->metric, nspid);
   }


### PR DESCRIPTION
fix: remove duplicate table fetch

There were two lines that fetched the Oid of the metric table, probably a
result of a merge, so we remove it here.

----

fix: error should not stop worker

If there is a syntax error in the received packet the parser will generate an
error and the worker will exit. Instead, the error is captured, the packet
skipped, and processing continues with the next packet.
