### PR TITLE
feat: automatically create tables 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.o
 *.so
+*.bc
 
 /results/**
 /.cache

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,7 @@ DATA = influx--0.4.sql
 MODULE_big = influx
 OBJS = influx.o worker.o network.o ingest.o cache.o metric.o
 
-REGRESS = parse worker inval
-REGRESS_OPTS += --load-extension=influx
+REGRESS = parse worker inval create
 
 package-version = $(shell git describe --long --match="v[0-9]*" | cut -d- -f1 | sed 's/^v//')
 dist-name = postgresql-pg-influx-$(package-version)

--- a/expected/create.out
+++ b/expected/create.out
@@ -1,0 +1,70 @@
+CREATE SCHEMA db_create;
+CREATE EXTENSION influx WITH SCHEMA db_create;
+SELECT pg_sleep(1) FROM db_create.worker_launch(4711::text);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+-- Should create the table
+\d db_create.*
+CALL db_create.send_packet('system,host=fury uptime=607641i 1574753954000000000', 4711::text);
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+\d db_create.*
+                      Table "db_create.system"
+ Column  |           Type           | Collation | Nullable | Default 
+---------+--------------------------+-----------+----------+---------
+ _time   | timestamp with time zone |           |          | 
+ _tags   | jsonb                    |           |          | 
+ _fields | jsonb                    |           |          | 
+
+DROP TABLE db_create.system;
+-- Replace the function with something else
+CREATE OR REPLACE FUNCTION db_create._create("metric" name, "tags" name[], "fields" name[])
+RETURNS regclass AS $$
+BEGIN
+   EXECUTE format('CREATE TABLE db_create.%I (_time timestamp, _fields json)', metric);
+   RETURN format('%I.%I', 'db_create', metric)::regclass;
+END;
+$$ LANGUAGE plpgsql;
+\d db_create.*
+CALL db_create.send_packet('disk,device=nvme0n1p1 free=527806464i 1574753954000000000', 4711::text);
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+\d db_create.*
+                         Table "db_create.disk"
+ Column  |            Type             | Collation | Nullable | Default 
+---------+-----------------------------+-----------+----------+---------
+ _time   | timestamp without time zone |           |          | 
+ _fields | json                        |           |          | 
+
+DROP TABLE db_create.disk;
+-- Drop the function to see that the tables are not auto-created
+ALTER EXTENSION influx DROP FUNCTION db_create._create;
+DROP FUNCTION db_create._create;
+\d db_create.*
+CALL db_create.send_packet('cpu,host=fury uptime=607641i 1574753954000000000', 4711::text);
+SELECT pg_sleep(1);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+\d db_create.*
+SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE backend_type like '%Influx%';
+ pg_terminate_backend 
+----------------------
+ t
+(1 row)
+
+DROP EXTENSION influx;
+DROP SCHEMA db_create;

--- a/expected/inval.out
+++ b/expected/inval.out
@@ -1,12 +1,13 @@
 CREATE SCHEMA db_worker;
 CREATE TABLE db_worker.cpu(_time timestamptz, _tags jsonb, _fields jsonb);
+CREATE EXTENSION influx WITH SCHEMA db_worker;
 \set VERBOSITY terse
 \x on
-SELECT pg_sleep(1) FROM worker_launch('db_worker', 4711::text);
+SELECT pg_sleep(1) FROM db_worker.worker_launch('db_worker', 4711::text);
 -[ RECORD 1 ]
 pg_sleep | 
 
-CALL send_packet('cpu,cpu=cpu0,host=fury usage_system=2.04,usage_user=5.40 1574753954000000000', 4711::text);
+CALL db_worker.send_packet('cpu,cpu=cpu0,host=fury usage_system=2.04,usage_user=5.40 1574753954000000000', 4711::text);
 SELECT pg_sleep(1);
 -[ RECORD 1 ]
 pg_sleep | 
@@ -18,7 +19,7 @@ _tags   | {"cpu": "cpu0", "host": "fury"}
 _fields | {"usage_user": "5.40", "usage_system": "2.04"}
 
 ALTER TABLE db_worker.cpu ADD COLUMN cpu text;
-CALL send_packet('cpu,cpu=cpu0,host=fury usage_system=2.04,usage_user=5.40 1574753955000000000', 4711::text);
+CALL db_worker.send_packet('cpu,cpu=cpu0,host=fury usage_system=2.04,usage_user=5.40 1574753955000000000', 4711::text);
 SELECT pg_sleep(1);
 -[ RECORD 1 ]
 pg_sleep | 
@@ -36,7 +37,7 @@ _fields | {"usage_user": "5.40", "usage_system": "2.04"}
 cpu     | cpu0
 
 ALTER TABLE db_worker.cpu ADD COLUMN host text;
-CALL send_packet('cpu,cpu=cpu0,host=fury usage_system=2.04,usage_user=5.40 1574753956000000000', 4711::text);
+CALL db_worker.send_packet('cpu,cpu=cpu0,host=fury usage_system=2.04,usage_user=5.40 1574753956000000000', 4711::text);
 SELECT pg_sleep(1);
 -[ RECORD 1 ]
 pg_sleep | 
@@ -65,5 +66,6 @@ SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE backend_type like '
 -[ RECORD 1 ]--------+--
 pg_terminate_backend | t
 
+DROP EXTENSION influx;
 DROP TABLE db_worker.cpu;
 DROP SCHEMA db_worker;

--- a/expected/parse.out
+++ b/expected/parse.out
@@ -1,3 +1,4 @@
+CREATE EXTENSION influx;
 -- Expect 2016-06-13T17:43:50.1004002Z (from protocol specification)
 select * from parse_influx('cpu foo=12 1465839830100400200');
  _metric |             _time             | _tags |    _fields    
@@ -108,3 +109,4 @@ SELECT * FROM (SELECT parse_influx(line) FROM lines) x;
  (system,"Tue Nov 26 07:39:14 2019","{""host"": ""fury""}","{""uptime_format"": ""7 days,  0:47""}")
 (29 rows)
 
+DROP EXTENSION influx;

--- a/expected/worker.out
+++ b/expected/worker.out
@@ -1,22 +1,22 @@
 CREATE SCHEMA db_worker;
-CREATE TABLE db_worker.cpu(_time timestamptz, _tags jsonb, _fields jsonb);
 CREATE TABLE db_worker.disk(_time timestamptz, host text, device text, _tags jsonb, _fields jsonb);
 CREATE TABLE db_worker.system(_time timestamp, host text, uptime int, _tags jsonb, _fields jsonb);
+CREATE EXTENSION influx WITH SCHEMA db_worker;
 \set VERBOSITY terse
 \x on
-SELECT pg_sleep(1), pid worker_pid FROM worker_launch('db_worker', 4711::text) pid \gset
-CALL send_packet('cpu,cpu=cpu0,host=fury usage_system=2.0408163264927324,usage_user=2.0408163264927324 1574753954000000000', 4711::text);
-CALL send_packet('cpu,cpu=cpu1,host=fury usage_system=3.921568627286635,usage_user=3.9215686274649673 1574753954000000000', 4711::text);
-CALL send_packet('disk,device=nvme0n1p2,fstype=ext4,host=fury,mode=rw,path=/ free=912578965504i,total=1006530654208i,used=42751348736i,used_percent=4.475033200428718 1574753954000000000', 4711::text);
-CALL send_packet('disk,device=nvme0n1p1,fstype=vfat,host=fury,mode=rw,path=/boot/efi free=527806464i,total=535805952i,used=7999488i,used_percent=1.4929822952022749 1574753954000000000', 4711::text);
-CALL send_packet('system,host=fury load1=2.13,load15=0.84,load5=1.18,n_cpus=8i,n_users=1i 1574753954000000000', 4711::text);
-CALL send_packet('system,host=fury uptime=607641i 1574753954000000000', 4711::text);
-CALL send_packet('system,host=fury uptime_format="7 days,  0:47" 1574753954000000000', 4711::text);
+SELECT pg_sleep(1), pid AS worker_pid FROM db_worker.worker_launch('db_worker', 4711::text) AS pid \gset
+CALL db_worker.send_packet('cpu,cpu=cpu0,host=fury usage_system=2.0408163264927324,usage_user=2.0408163264927324 1574753954000000000', 4711::text);
+CALL db_worker.send_packet('cpu,cpu=cpu1,host=fury usage_system=3.921568627286635,usage_user=3.9215686274649673 1574753954000000000', 4711::text);
+CALL db_worker.send_packet('disk,device=nvme0n1p2,fstype=ext4,host=fury,mode=rw,path=/ free=912578965504i,total=1006530654208i,used=42751348736i,used_percent=4.475033200428718 1574753954000000000', 4711::text);
+CALL db_worker.send_packet('disk,device=nvme0n1p1,fstype=vfat,host=fury,mode=rw,path=/boot/efi free=527806464i,total=535805952i,used=7999488i,used_percent=1.4929822952022749 1574753954000000000', 4711::text);
+CALL db_worker.send_packet('system,host=fury load1=2.13,load15=0.84,load5=1.18,n_cpus=8i,n_users=1i 1574753954000000000', 4711::text);
+CALL db_worker.send_packet('system,host=fury uptime=607641i 1574753954000000000', 4711::text);
+CALL db_worker.send_packet('system,host=fury uptime_format="7 days,  0:47" 1574753954000000000', 4711::text);
 SELECT pg_sleep(2);
 -[ RECORD 1 ]
 pg_sleep | 
 
-SELECT * FROM db_worker.cpu;
+SELECT * FROM db_worker.cpu;	--Automatically created
 -[ RECORD 1 ]-----------------------------------------------------------------------
 _time   | Mon Nov 25 23:39:14 2019 PST
 _tags   | {"cpu": "cpu0", "host": "fury"}
@@ -65,7 +65,7 @@ SELECT count(*) FROM pg_stat_activity WHERE pid = :worker_pid;
 count | 1
 
 -- Syntax error, but the worker should not stop
-CALL send_packet('system,host=fury', 4711::text);
+CALL db_worker.send_packet('system,host=fury', 4711::text);
 SELECT pg_sleep(1);
 -[ RECORD 1 ]
 pg_sleep | 
@@ -78,6 +78,7 @@ SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE backend_type like '
 -[ RECORD 1 ]--------+--
 pg_terminate_backend | t
 
+DROP EXTENSION influx;
 DROP TABLE db_worker.cpu;
 DROP TABLE db_worker.disk;
 DROP TABLE db_worker.system;

--- a/influx--0.4.sql
+++ b/influx--0.4.sql
@@ -6,6 +6,10 @@ CREATE FUNCTION worker_launch(ns regnamespace, service text)
 RETURNS integer
 LANGUAGE C AS '$libdir/influx.so';
 
+CREATE FUNCTION worker_launch(service text)
+RETURNS integer
+LANGUAGE C AS '$libdir/influx.so';
+
 -- Send a packet over UDP to a host and service
 CREATE PROCEDURE send_packet(packet text, service text, hostname text = 'localhost')
 LANGUAGE C AS '$libdir/influx.so';
@@ -14,3 +18,7 @@ LANGUAGE C AS '$libdir/influx.so';
 CREATE FUNCTION parse_influx(text)
 RETURNS TABLE (_metric text, _time timestamp, _tags jsonb, _fields jsonb)
 LANGUAGE C AS '$libdir/influx.so';
+
+CREATE FUNCTION _create("metric" name, "tags" name[], "fields" name[])
+RETURNS regclass
+LANGUAGE C AS '$libdir/influx.so', 'default_create';

--- a/metric.h
+++ b/metric.h
@@ -45,7 +45,8 @@ typedef struct Metric {
   List *fields;
 } Metric;
 
-void MetricInsert(Metric *metric, int nspid);
+Oid MetricCreate(Metric *metric, Oid nspid);
+void MetricInsert(Metric *metric, Oid nspid);
 bool CollectValues(Metric *metric, AttInMetadata *attinmeta, Oid *argtypes,
                    Datum *values, bool *nulls);
 

--- a/sql/create.sql
+++ b/sql/create.sql
@@ -1,0 +1,39 @@
+CREATE SCHEMA db_create;
+CREATE EXTENSION influx WITH SCHEMA db_create;
+SELECT pg_sleep(1) FROM db_create.worker_launch(4711::text);
+
+-- Should create the table
+\d db_create.*
+CALL db_create.send_packet('system,host=fury uptime=607641i 1574753954000000000', 4711::text);
+SELECT pg_sleep(1);
+\d db_create.*
+DROP TABLE db_create.system;
+
+-- Replace the function with something else
+CREATE OR REPLACE FUNCTION db_create._create("metric" name, "tags" name[], "fields" name[])
+RETURNS regclass AS $$
+BEGIN
+   EXECUTE format('CREATE TABLE db_create.%I (_time timestamp, _fields json)', metric);
+   RETURN format('%I.%I', 'db_create', metric)::regclass;
+END;
+$$ LANGUAGE plpgsql;
+
+\d db_create.*
+CALL db_create.send_packet('disk,device=nvme0n1p1 free=527806464i 1574753954000000000', 4711::text);
+SELECT pg_sleep(1);
+\d db_create.*
+DROP TABLE db_create.disk;
+
+-- Drop the function to see that the tables are not auto-created
+ALTER EXTENSION influx DROP FUNCTION db_create._create;
+DROP FUNCTION db_create._create;
+
+\d db_create.*
+CALL db_create.send_packet('cpu,host=fury uptime=607641i 1574753954000000000', 4711::text);
+SELECT pg_sleep(1);
+\d db_create.*
+
+SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE backend_type like '%Influx%';
+
+DROP EXTENSION influx;
+DROP SCHEMA db_create;

--- a/sql/inval.sql
+++ b/sql/inval.sql
@@ -1,21 +1,24 @@
 CREATE SCHEMA db_worker;
 CREATE TABLE db_worker.cpu(_time timestamptz, _tags jsonb, _fields jsonb);
 
+CREATE EXTENSION influx WITH SCHEMA db_worker;
+
 \set VERBOSITY terse
 \x on
-SELECT pg_sleep(1) FROM worker_launch('db_worker', 4711::text);
-CALL send_packet('cpu,cpu=cpu0,host=fury usage_system=2.04,usage_user=5.40 1574753954000000000', 4711::text);
+SELECT pg_sleep(1) FROM db_worker.worker_launch('db_worker', 4711::text);
+CALL db_worker.send_packet('cpu,cpu=cpu0,host=fury usage_system=2.04,usage_user=5.40 1574753954000000000', 4711::text);
 SELECT pg_sleep(1);
 SELECT * FROM db_worker.cpu;
 ALTER TABLE db_worker.cpu ADD COLUMN cpu text;
-CALL send_packet('cpu,cpu=cpu0,host=fury usage_system=2.04,usage_user=5.40 1574753955000000000', 4711::text);
+CALL db_worker.send_packet('cpu,cpu=cpu0,host=fury usage_system=2.04,usage_user=5.40 1574753955000000000', 4711::text);
 SELECT pg_sleep(1);
 SELECT * FROM db_worker.cpu;
 ALTER TABLE db_worker.cpu ADD COLUMN host text;
-CALL send_packet('cpu,cpu=cpu0,host=fury usage_system=2.04,usage_user=5.40 1574753956000000000', 4711::text);
+CALL db_worker.send_packet('cpu,cpu=cpu0,host=fury usage_system=2.04,usage_user=5.40 1574753956000000000', 4711::text);
 SELECT pg_sleep(1);
 SELECT * FROM db_worker.cpu;
 SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE backend_type like '%Influx%';
 
+DROP EXTENSION influx;
 DROP TABLE db_worker.cpu;
 DROP SCHEMA db_worker;

--- a/sql/parse.sql
+++ b/sql/parse.sql
@@ -1,3 +1,5 @@
+CREATE EXTENSION influx;
+
 -- Expect 2016-06-13T17:43:50.1004002Z (from protocol specification)
 select * from parse_influx('cpu foo=12 1465839830100400200');
 
@@ -51,3 +53,5 @@ system,host=fury uptime_format="7 days,  0:47" 1574753954000000000
 \.
 
 SELECT * FROM (SELECT parse_influx(line) FROM lines) x;
+
+DROP EXTENSION influx;

--- a/sql/worker.sql
+++ b/sql/worker.sql
@@ -1,32 +1,34 @@
 CREATE SCHEMA db_worker;
-CREATE TABLE db_worker.cpu(_time timestamptz, _tags jsonb, _fields jsonb);
 CREATE TABLE db_worker.disk(_time timestamptz, host text, device text, _tags jsonb, _fields jsonb);
 CREATE TABLE db_worker.system(_time timestamp, host text, uptime int, _tags jsonb, _fields jsonb);
 
+CREATE EXTENSION influx WITH SCHEMA db_worker;
+
 \set VERBOSITY terse
 \x on
-SELECT pg_sleep(1), pid worker_pid FROM worker_launch('db_worker', 4711::text) pid \gset
-CALL send_packet('cpu,cpu=cpu0,host=fury usage_system=2.0408163264927324,usage_user=2.0408163264927324 1574753954000000000', 4711::text);
-CALL send_packet('cpu,cpu=cpu1,host=fury usage_system=3.921568627286635,usage_user=3.9215686274649673 1574753954000000000', 4711::text);
-CALL send_packet('disk,device=nvme0n1p2,fstype=ext4,host=fury,mode=rw,path=/ free=912578965504i,total=1006530654208i,used=42751348736i,used_percent=4.475033200428718 1574753954000000000', 4711::text);
-CALL send_packet('disk,device=nvme0n1p1,fstype=vfat,host=fury,mode=rw,path=/boot/efi free=527806464i,total=535805952i,used=7999488i,used_percent=1.4929822952022749 1574753954000000000', 4711::text);
-CALL send_packet('system,host=fury load1=2.13,load15=0.84,load5=1.18,n_cpus=8i,n_users=1i 1574753954000000000', 4711::text);
-CALL send_packet('system,host=fury uptime=607641i 1574753954000000000', 4711::text);
-CALL send_packet('system,host=fury uptime_format="7 days,  0:47" 1574753954000000000', 4711::text);
+SELECT pg_sleep(1), pid AS worker_pid FROM db_worker.worker_launch('db_worker', 4711::text) AS pid \gset
+CALL db_worker.send_packet('cpu,cpu=cpu0,host=fury usage_system=2.0408163264927324,usage_user=2.0408163264927324 1574753954000000000', 4711::text);
+CALL db_worker.send_packet('cpu,cpu=cpu1,host=fury usage_system=3.921568627286635,usage_user=3.9215686274649673 1574753954000000000', 4711::text);
+CALL db_worker.send_packet('disk,device=nvme0n1p2,fstype=ext4,host=fury,mode=rw,path=/ free=912578965504i,total=1006530654208i,used=42751348736i,used_percent=4.475033200428718 1574753954000000000', 4711::text);
+CALL db_worker.send_packet('disk,device=nvme0n1p1,fstype=vfat,host=fury,mode=rw,path=/boot/efi free=527806464i,total=535805952i,used=7999488i,used_percent=1.4929822952022749 1574753954000000000', 4711::text);
+CALL db_worker.send_packet('system,host=fury load1=2.13,load15=0.84,load5=1.18,n_cpus=8i,n_users=1i 1574753954000000000', 4711::text);
+CALL db_worker.send_packet('system,host=fury uptime=607641i 1574753954000000000', 4711::text);
+CALL db_worker.send_packet('system,host=fury uptime_format="7 days,  0:47" 1574753954000000000', 4711::text);
 SELECT pg_sleep(2);
 
-SELECT * FROM db_worker.cpu;
+SELECT * FROM db_worker.cpu;	--Automatically created
 SELECT * FROM db_worker.disk;
 SELECT * FROM db_worker.system;
 
 SELECT count(*) FROM pg_stat_activity WHERE pid = :worker_pid;
 -- Syntax error, but the worker should not stop
-CALL send_packet('system,host=fury', 4711::text);
+CALL db_worker.send_packet('system,host=fury', 4711::text);
 SELECT pg_sleep(1);
 SELECT count(*) FROM pg_stat_activity WHERE pid = :worker_pid;
 
 SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE backend_type like '%Influx%';
 
+DROP EXTENSION influx;
 DROP TABLE db_worker.cpu;
 DROP TABLE db_worker.disk;
 DROP TABLE db_worker.system;

--- a/worker.c
+++ b/worker.c
@@ -258,8 +258,9 @@ void InfluxWorkerMain(Datum arg) {
  * @param schema Schema name where tables for metrics are stored.
  */
 Datum worker_launch(PG_FUNCTION_ARGS) {
-  Oid nspid = PG_GETARG_OID(0);
-  char *service = text_to_cstring(PG_GETARG_TEXT_P(1));
+  Oid nspid = PG_NARGS() == 1 ? get_func_namespace(fcinfo->flinfo->fn_oid)
+                              : PG_GETARG_OID(0);
+  char *service = text_to_cstring(PG_GETARG_TEXT_P(PG_NARGS() == 1 ? 0 : 1));
   BackgroundWorker worker;
   BackgroundWorkerHandle *handle;
   BgwHandleStatus status;


### PR DESCRIPTION
When a metric is received that does not have a corresponding table, it will
search for a function named `_create` in the schema where the extension is
installed. If such a function is found, it will be called with the metric, an
array of tags, and an array of field names that was part of the packet. If the
function returns an OID of a relation, that will be used to as target for the
row. If `InvalidOid` is returned, it is assumed that no table is created and
the row will be ignored.