### PR TITLE
refactor!: move UDP worker to separate file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         DEBIAN_FRONTEND: noninteractiv
       run: |
         apt-get update
-        apt-get install -qy make gcc postgresql-server-dev-${{ matrix.version }} postgresql-client-${{ matrix.version }}
+        apt-get install -qy make gcc postgresql-server-dev-${{ matrix.version }}
     - uses: actions/checkout@v3
     - name: Build extensions
       run: make
@@ -33,7 +33,11 @@ jobs:
     - name: Wait for server to start
       env:
         PGUSER: postgres
-      run: sleep 10 && pg_isready -t20
+        PGHOST: localhost
+      run: |
+        sleep 10
+        tail /var/log/postgresql/postgresql.log
+        pg_isready --timeout=20
     - name: Run tests
       env:
         PGUSER: postgres

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 EXTENSION = influx
 DATA = influx--0.4.sql
 MODULE_big = influx
-OBJS = influx.o worker.o network.o ingest.o cache.o metric.o
+OBJS = influx.o worker.o network.o ingest.o cache.o metric.o guc.o udp.o
 
 REGRESS = parse worker inval create
 
@@ -33,9 +33,10 @@ dist:
 	git archive --prefix=$(dist-name)/ --format=tar.gz -o $(dist-file) HEAD
 
 cache.o: cache.c cache.h
-influx.o: influx.c influx.h ingest.h metric.h worker.h
+guc.o: guc.c guc.h
+influx.o: influx.c influx.h ingest.h metric.h guc.h udp.h worker.h
 ingest.o: ingest.c ingest.h metric.h
-metric.o: metric.c metric.h cache.h
+metric.o: metric.c metric.h cache.h worker.h
 network.o: network.c network.h
-worker.o: worker.c worker.h cache.h influx.h ingest.h metric.h network.h
-
+udp.o: udp.c udp.h worker.h guc.h network.h
+worker.o: worker.c worker.h cache.h influx.h ingest.h metric.h

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,22 +5,23 @@ it in a schema and launch a worker process for that schema.
 
 ```sql
 CREATE EXTENSION influx WITH SCHEMA metrics;
-SELECT metrics.worker_launch('8089');
+SELECT metrics.launch_udp_worker('8089');
 ```
 
 This will spawn a single worker that will listen to socket 8089. The
-`worker_launch` procedure will assume that the worker is for that
+`launch_udp_worker` procedure will assume that the worker is for that
 schema.
 
 > **NOTE:** PostgreSQL does not allow installing an extension multiple
 > times in the same database, so you cannot use this method to launch
 > workers for different schema. If you want to do that, you need to
-> use the [2-argument version of `worker_launch`][1]. If you do that,
-> however, you will not be able to start workers automatically in the
-> background since you can (currently) only give one schema for the
-> workers and not have several workers writing to different schema.
+> use the [2-argument version of `launch_udp_worker`][1]. If you do
+> that, however, you will not be able to start workers automatically
+> in the background since you can (currently) only give one schema for
+> the workers and not have several workers writing to different
+> schema.
 
-[1]: procedures.md#function-worker_launch
+[1]: procedures.md#function-launch_udp_worker
 
 ## Automatically starting listeners
 

--- a/docs/procedures.md
+++ b/docs/procedures.md
@@ -2,13 +2,13 @@
 
 ## Table of Contents
 
-1. [Procedure `send_packet`](#procedure-send_packet)
-2. [Function `worker_launch`](#function-worker_launch)
+1. [Procedure `send_udp_packet`](#procedure-send_udp_packet)
+2. [Function `launch_udp_worker`](#function-launch_udp_worker)
 3. [Function `_create`](#function-_create)
 
-## Function `worker_launch`
+## Function `launch_udp_worker`
 
-Launch a new background worker.
+Launch a new UDP background worker.
 
 The service is looked up using `getaddrinfo` so it is possible to
 either provide a port number of service name that will be translated
@@ -39,7 +39,7 @@ If you have installed the extension in the schema `metrics` you can
 spawn a worker listening on socket 8089 using:
 
 ```sql
-SELECT metrics.worker_launch('8089');
+SELECT metrics.launch_udp_worker('8089');
 ```
 
 If you have installed the extension in the `public` schema (which is
@@ -47,21 +47,21 @@ the default if you do not give a schema when using [`CREATE
 EXTENSION`]()) you can start a worker using:
 
 ```sql
-SELECT worker_launch('metrics', '8089');
+SELECT launch_udp_worker('metrics', '8089');
 ```
 
 If you want to terminate a previously started worker, you can save the
 PID in a `psql` variable:
 
 ```sql
-SELECT metrics.worker_launch('8089') as pid \gset
+SELECT metrics.launch_udp_worker('8089') as pid \gset
    .
    .
    .
 SELECT pg_terminate_backend(:pid);
 ```
 
-## Procedure `send_packet`
+## Procedure `send_udp_packet`
 
 Send a UDP packet to a network address.
 

--- a/expected/create.out
+++ b/expected/create.out
@@ -1,6 +1,6 @@
 CREATE SCHEMA db_create;
 CREATE EXTENSION influx WITH SCHEMA db_create;
-SELECT pg_sleep(1) FROM db_create.worker_launch(4711::text);
+SELECT pg_sleep(1) FROM db_create.launch_udp_worker(4711::text);
  pg_sleep 
 ----------
  
@@ -8,7 +8,7 @@ SELECT pg_sleep(1) FROM db_create.worker_launch(4711::text);
 
 -- Should create the table
 \d db_create.*
-CALL db_create.send_packet('system,host=fury uptime=607641i 1574753954000000000', 4711::text);
+CALL db_create.send_udp_packet('system,host=fury uptime=607641i 1574753954000000000', 4711::text);
 SELECT pg_sleep(1);
  pg_sleep 
 ----------
@@ -33,7 +33,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 \d db_create.*
-CALL db_create.send_packet('disk,device=nvme0n1p1 free=527806464i 1574753954000000000', 4711::text);
+CALL db_create.send_udp_packet('disk,device=nvme0n1p1 free=527806464i 1574753954000000000', 4711::text);
 SELECT pg_sleep(1);
  pg_sleep 
 ----------
@@ -52,7 +52,7 @@ DROP TABLE db_create.disk;
 ALTER EXTENSION influx DROP FUNCTION db_create._create;
 DROP FUNCTION db_create._create;
 \d db_create.*
-CALL db_create.send_packet('cpu,host=fury uptime=607641i 1574753954000000000', 4711::text);
+CALL db_create.send_udp_packet('cpu,host=fury uptime=607641i 1574753954000000000', 4711::text);
 SELECT pg_sleep(1);
  pg_sleep 
 ----------

--- a/expected/inval.out
+++ b/expected/inval.out
@@ -3,11 +3,11 @@ CREATE TABLE db_worker.cpu(_time timestamptz, _tags jsonb, _fields jsonb);
 CREATE EXTENSION influx WITH SCHEMA db_worker;
 \set VERBOSITY terse
 \x on
-SELECT pg_sleep(1) FROM db_worker.worker_launch('db_worker', 4711::text);
+SELECT pg_sleep(1) FROM db_worker.launch_udp_worker('db_worker', 4711::text);
 -[ RECORD 1 ]
 pg_sleep | 
 
-CALL db_worker.send_packet('cpu,cpu=cpu0,host=fury usage_system=2.04,usage_user=5.40 1574753954000000000', 4711::text);
+CALL db_worker.send_udp_packet('cpu,cpu=cpu0,host=fury usage_system=2.04,usage_user=5.40 1574753954000000000', 4711::text);
 SELECT pg_sleep(1);
 -[ RECORD 1 ]
 pg_sleep | 
@@ -19,7 +19,7 @@ _tags   | {"cpu": "cpu0", "host": "fury"}
 _fields | {"usage_user": "5.40", "usage_system": "2.04"}
 
 ALTER TABLE db_worker.cpu ADD COLUMN cpu text;
-CALL db_worker.send_packet('cpu,cpu=cpu0,host=fury usage_system=2.04,usage_user=5.40 1574753955000000000', 4711::text);
+CALL db_worker.send_udp_packet('cpu,cpu=cpu0,host=fury usage_system=2.04,usage_user=5.40 1574753955000000000', 4711::text);
 SELECT pg_sleep(1);
 -[ RECORD 1 ]
 pg_sleep | 
@@ -37,7 +37,7 @@ _fields | {"usage_user": "5.40", "usage_system": "2.04"}
 cpu     | cpu0
 
 ALTER TABLE db_worker.cpu ADD COLUMN host text;
-CALL db_worker.send_packet('cpu,cpu=cpu0,host=fury usage_system=2.04,usage_user=5.40 1574753956000000000', 4711::text);
+CALL db_worker.send_udp_packet('cpu,cpu=cpu0,host=fury usage_system=2.04,usage_user=5.40 1574753956000000000', 4711::text);
 SELECT pg_sleep(1);
 -[ RECORD 1 ]
 pg_sleep | 

--- a/expected/worker.out
+++ b/expected/worker.out
@@ -4,14 +4,14 @@ CREATE TABLE db_worker.system(_time timestamp, host text, uptime int, _tags json
 CREATE EXTENSION influx WITH SCHEMA db_worker;
 \set VERBOSITY terse
 \x on
-SELECT pg_sleep(1), pid AS worker_pid FROM db_worker.worker_launch('db_worker', 4711::text) AS pid \gset
-CALL db_worker.send_packet('cpu,cpu=cpu0,host=fury usage_system=2.0408163264927324,usage_user=2.0408163264927324 1574753954000000000', 4711::text);
-CALL db_worker.send_packet('cpu,cpu=cpu1,host=fury usage_system=3.921568627286635,usage_user=3.9215686274649673 1574753954000000000', 4711::text);
-CALL db_worker.send_packet('disk,device=nvme0n1p2,fstype=ext4,host=fury,mode=rw,path=/ free=912578965504i,total=1006530654208i,used=42751348736i,used_percent=4.475033200428718 1574753954000000000', 4711::text);
-CALL db_worker.send_packet('disk,device=nvme0n1p1,fstype=vfat,host=fury,mode=rw,path=/boot/efi free=527806464i,total=535805952i,used=7999488i,used_percent=1.4929822952022749 1574753954000000000', 4711::text);
-CALL db_worker.send_packet('system,host=fury load1=2.13,load15=0.84,load5=1.18,n_cpus=8i,n_users=1i 1574753954000000000', 4711::text);
-CALL db_worker.send_packet('system,host=fury uptime=607641i 1574753954000000000', 4711::text);
-CALL db_worker.send_packet('system,host=fury uptime_format="7 days,  0:47" 1574753954000000000', 4711::text);
+SELECT pg_sleep(1), pid AS worker_pid FROM db_worker.launch_udp_worker('db_worker', 4711::text) AS pid \gset
+CALL db_worker.send_udp_packet('cpu,cpu=cpu0,host=fury usage_system=2.0408163264927324,usage_user=2.0408163264927324 1574753954000000000', 4711::text);
+CALL db_worker.send_udp_packet('cpu,cpu=cpu1,host=fury usage_system=3.921568627286635,usage_user=3.9215686274649673 1574753954000000000', 4711::text);
+CALL db_worker.send_udp_packet('disk,device=nvme0n1p2,fstype=ext4,host=fury,mode=rw,path=/ free=912578965504i,total=1006530654208i,used=42751348736i,used_percent=4.475033200428718 1574753954000000000', 4711::text);
+CALL db_worker.send_udp_packet('disk,device=nvme0n1p1,fstype=vfat,host=fury,mode=rw,path=/boot/efi free=527806464i,total=535805952i,used=7999488i,used_percent=1.4929822952022749 1574753954000000000', 4711::text);
+CALL db_worker.send_udp_packet('system,host=fury load1=2.13,load15=0.84,load5=1.18,n_cpus=8i,n_users=1i 1574753954000000000', 4711::text);
+CALL db_worker.send_udp_packet('system,host=fury uptime=607641i 1574753954000000000', 4711::text);
+CALL db_worker.send_udp_packet('system,host=fury uptime_format="7 days,  0:47" 1574753954000000000', 4711::text);
 SELECT pg_sleep(2);
 -[ RECORD 1 ]
 pg_sleep | 
@@ -65,7 +65,7 @@ SELECT count(*) FROM pg_stat_activity WHERE pid = :worker_pid;
 count | 1
 
 -- Syntax error, but the worker should not stop
-CALL db_worker.send_packet('system,host=fury', 4711::text);
+CALL db_worker.send_udp_packet('system,host=fury', 4711::text);
 SELECT pg_sleep(1);
 -[ RECORD 1 ]
 pg_sleep | 

--- a/guc.c
+++ b/guc.c
@@ -1,0 +1,66 @@
+#include "guc.h"
+
+#include <postgres.h>
+
+#include <utils/guc.h>
+
+/** Number of Influx protocol workers. */
+int InfluxWorkersCount;
+
+/** Service name to listen on. */
+char *InfluxServiceName;
+
+/** Schema name to use for metrics. */
+char *InfluxSchemaName;
+
+/** Database name to work with. */
+char *InfluxDatabaseName;
+
+/** Role name to use when connecting to the database. */
+char *InfluxRoleName;
+
+void InfluxGucInitDynamic(void) {
+  DefineCustomIntVariable("influx.workers",     /* option name */
+                          "Number of workers.", /* short descriptor */
+                          "Number of workers to spawn when starting up"
+                          "the server.",       /* long description */
+                          &InfluxWorkersCount, /* value address */
+                          4,                   /* boot value */
+                          0,                   /* min value */
+                          20,                  /* max value */
+                          PGC_SIGHUP,          /* option context */
+                          0,                   /* option flags */
+                          NULL,                /* check hook */
+                          NULL,                /* assign hook */
+                          NULL);               /* show hook */
+}
+
+void InfluxGucInitStatic(void) {
+  /* Right now we have only UDP supported, so we use 8089. If we decide to
+   * support more protocols, we should dynamically pick the default based on the
+   * protocol. */
+  DefineCustomStringVariable(
+      "influx.service", "Service name.",
+      "Service name to listen on, or port number. If it is a service name, it"
+      " will be looked up.If it is a port, it will be used as it is.",
+      &InfluxServiceName, "8089", PGC_POSTMASTER, 0, NULL, NULL, NULL);
+  DefineCustomStringVariable(
+      "influx.database", "Database name.", "Database name to connect to.",
+      &InfluxDatabaseName, NULL, PGC_POSTMASTER, 0, NULL, NULL, NULL);
+  DefineCustomStringVariable(
+      "influx.role", "Role name.",
+      "Role name to use when connecting to the database. Default is to"
+      " connect as superuser.",
+      &InfluxRoleName, NULL, PGC_POSTMASTER, 0, NULL, NULL, NULL);
+  DefineCustomStringVariable(
+      "influx.schema", "Schema name.",
+      "Schema name to use for the workers. This is where the measurement"
+      " tables should be placed.",
+      &InfluxSchemaName, NULL, PGC_POSTMASTER, 0, NULL, NULL, NULL);
+
+  elog(LOG,
+       "InfluxDatabaseName: %s, InfluxSchemaName: %s, InfluxServiceName: %s, "
+       "InfluxRoleName: %s, InfluxWorkersCount: %d",
+       InfluxDatabaseName, InfluxSchemaName, InfluxServiceName, InfluxRoleName,
+       InfluxWorkersCount);
+}

--- a/guc.h
+++ b/guc.h
@@ -1,0 +1,13 @@
+#ifndef GUC_H_
+#define GUC_H_
+
+extern int InfluxWorkersCount;
+extern char *InfluxServiceName;
+extern char *InfluxSchemaName;
+extern char *InfluxDatabaseName;
+extern char *InfluxRoleName;
+
+extern void InfluxGucInitDynamic(void);
+extern void InfluxGucInitStatic(void);
+
+#endif /* GUC_H_ */

--- a/influx--0.4.sql
+++ b/influx--0.4.sql
@@ -2,16 +2,16 @@
 \echo Use "CREATE EXTENSION influx" to load this file. \quit
 
 -- Launch a new worker that listens on a port and writes to a namespace
-CREATE FUNCTION worker_launch(ns regnamespace, service text)
+CREATE FUNCTION launch_udp_worker(ns regnamespace, service text)
 RETURNS integer
 LANGUAGE C AS '$libdir/influx.so';
 
-CREATE FUNCTION worker_launch(service text)
+CREATE FUNCTION launch_udp_worker(service text)
 RETURNS integer
 LANGUAGE C AS '$libdir/influx.so';
 
 -- Send a packet over UDP to a host and service
-CREATE PROCEDURE send_packet(packet text, service text, hostname text = 'localhost')
+CREATE PROCEDURE send_udp_packet(packet text, service text, hostname text = 'localhost')
 LANGUAGE C AS '$libdir/influx.so';
 
 -- Parse InfluxDB Line Protocol packet

--- a/influx.c
+++ b/influx.c
@@ -34,7 +34,9 @@
 #include <stdbool.h>
 #include <string.h>
 
+#include "guc.h"
 #include "ingest.h"
+#include "udp.h"
 #include "worker.h"
 
 PG_MODULE_MAGIC;
@@ -42,21 +44,6 @@ PG_MODULE_MAGIC;
 PG_FUNCTION_INFO_V1(parse_influx);
 
 void PGDLLEXPORT _PG_init(void);
-
-/** Number of Influx protocol workers. */
-static int InfluxWorkersCount;
-
-/** Service name to listen on. */
-static char *InfluxServiceName;
-
-/** Schema name to use for metrics. */
-static char *InfluxSchemaName;
-
-/** Database name to work with. */
-static char *InfluxDatabaseName;
-
-/** Role name to use when connecting to the database. */
-static char *InfluxRoleName;
 
 /** Parser state setup. */
 IngestState *ParseInfluxSetup(char *buffer) {
@@ -147,11 +134,9 @@ Datum parse_influx(PG_FUNCTION_ARGS) {
 static void StartBackgroundWorkers(const char *database_name,
                                    const char *schema_name,
                                    const char *role_name,
-                                   const char *service_name, int worker_count) {
+                                   const char *service_name) {
   MemoryContext oldcontext = MemoryContextSwitchTo(TopMemoryContext);
   WorkerArgs args = {0};
-  int i;
-  BackgroundWorker worker;
 
   if (schema_name)
     strncpy(args.namespace, schema_name, sizeof(args.namespace));
@@ -162,63 +147,17 @@ static void StartBackgroundWorkers(const char *database_name,
   if (service_name)
     strncpy(args.service, service_name, sizeof(args.service));
 
-  elog(LOG, "starting influx workers");
-
-  InfluxWorkerInit(&worker, &args);
-  elog(LOG, "memory allocated in %s memory context",
-       CurrentMemoryContext->name);
-  for (i = 0; i < worker_count; i++)
-    RegisterBackgroundWorker(&worker);
-  elog(LOG, "background workers started");
+  StartUdpBackgroundWorkers(&args);
   MemoryContextSwitchTo(oldcontext);
 }
 
 void _PG_init(void) {
-  DefineCustomIntVariable("influx.workers",     /* option name */
-                          "Number of workers.", /* short descriptor */
-                          "Number of workers to spawn when starting up"
-                          "the server.",       /* long description */
-                          &InfluxWorkersCount, /* value address */
-                          4,                   /* boot value */
-                          0,                   /* min value */
-                          20,                  /* max value */
-                          PGC_SIGHUP,          /* option context */
-                          0,                   /* option flags */
-                          NULL,                /* check hook */
-                          NULL,                /* assign hook */
-                          NULL);               /* show hook */
+  InfluxGucInitDynamic();
 
   if (!process_shared_preload_libraries_in_progress)
     return;
 
-  /* Right now we have only UDP supported, so we use 8089. If we decide to
-   * support more protocols, we should dynamically pick the default based on the
-   * protocol. */
-  DefineCustomStringVariable(
-      "influx.service", "Service name.",
-      "Service name to listen on, or port number. If it is a service name, it"
-      " will be looked up.If it is a port, it will be used as it is.",
-      &InfluxServiceName, "8089", PGC_POSTMASTER, 0, NULL, NULL, NULL);
-  DefineCustomStringVariable(
-      "influx.database", "Database name.", "Database name to connect to.",
-      &InfluxDatabaseName, NULL, PGC_POSTMASTER, 0, NULL, NULL, NULL);
-  DefineCustomStringVariable(
-      "influx.role", "Role name.",
-      "Role name to use when connecting to the database. Default is to"
-      " connect as superuser.",
-      &InfluxRoleName, NULL, PGC_POSTMASTER, 0, NULL, NULL, NULL);
-  DefineCustomStringVariable(
-      "influx.schema", "Schema name.",
-      "Schema name to use for the workers. This is where the measurement"
-      " tables should be placed.",
-      &InfluxSchemaName, NULL, PGC_POSTMASTER, 0, NULL, NULL, NULL);
-
-  elog(LOG,
-       "InfluxDatabaseName: %s, InfluxSchemaName: %s, InfluxServiceName: %s, "
-       "InfluxRoleName: %s, InfluxWorkersCount: %d",
-       InfluxDatabaseName, InfluxSchemaName, InfluxServiceName, InfluxRoleName,
-       InfluxWorkersCount);
-
+  InfluxGucInitStatic();
   StartBackgroundWorkers(InfluxDatabaseName, InfluxSchemaName, InfluxRoleName,
-                         InfluxServiceName, InfluxWorkersCount);
+                         InfluxServiceName);
 }

--- a/metric.h
+++ b/metric.h
@@ -45,8 +45,8 @@ typedef struct Metric {
   List *fields;
 } Metric;
 
-Oid MetricCreate(Metric *metric, Oid nspid);
-void MetricInsert(Metric *metric, Oid nspid);
+Oid MetricCreate(Metric *metric);
+void MetricInsert(Metric *metric);
 bool CollectValues(Metric *metric, AttInMetadata *attinmeta, Oid *argtypes,
                    Datum *values, bool *nulls);
 

--- a/network.c
+++ b/network.c
@@ -149,8 +149,8 @@ int CreateSocket(const char* hostname, const char* service,
   return STATUS_ERROR;
 }
 
-PG_FUNCTION_INFO_V1(send_packet);
-Datum send_packet(PG_FUNCTION_ARGS) {
+PG_FUNCTION_INFO_V1(send_udp_packet);
+Datum send_udp_packet(PG_FUNCTION_ARGS) {
   struct sockaddr_storage serveraddr;
   const char* hostname = text_to_cstring(PG_GETARG_TEXT_P(2));
   const char* service = text_to_cstring(PG_GETARG_TEXT_P(1));

--- a/sql/create.sql
+++ b/sql/create.sql
@@ -1,10 +1,10 @@
 CREATE SCHEMA db_create;
 CREATE EXTENSION influx WITH SCHEMA db_create;
-SELECT pg_sleep(1) FROM db_create.worker_launch(4711::text);
+SELECT pg_sleep(1) FROM db_create.launch_udp_worker(4711::text);
 
 -- Should create the table
 \d db_create.*
-CALL db_create.send_packet('system,host=fury uptime=607641i 1574753954000000000', 4711::text);
+CALL db_create.send_udp_packet('system,host=fury uptime=607641i 1574753954000000000', 4711::text);
 SELECT pg_sleep(1);
 \d db_create.*
 DROP TABLE db_create.system;
@@ -19,7 +19,7 @@ END;
 $$ LANGUAGE plpgsql;
 
 \d db_create.*
-CALL db_create.send_packet('disk,device=nvme0n1p1 free=527806464i 1574753954000000000', 4711::text);
+CALL db_create.send_udp_packet('disk,device=nvme0n1p1 free=527806464i 1574753954000000000', 4711::text);
 SELECT pg_sleep(1);
 \d db_create.*
 DROP TABLE db_create.disk;
@@ -29,7 +29,7 @@ ALTER EXTENSION influx DROP FUNCTION db_create._create;
 DROP FUNCTION db_create._create;
 
 \d db_create.*
-CALL db_create.send_packet('cpu,host=fury uptime=607641i 1574753954000000000', 4711::text);
+CALL db_create.send_udp_packet('cpu,host=fury uptime=607641i 1574753954000000000', 4711::text);
 SELECT pg_sleep(1);
 \d db_create.*
 

--- a/sql/inval.sql
+++ b/sql/inval.sql
@@ -5,16 +5,16 @@ CREATE EXTENSION influx WITH SCHEMA db_worker;
 
 \set VERBOSITY terse
 \x on
-SELECT pg_sleep(1) FROM db_worker.worker_launch('db_worker', 4711::text);
-CALL db_worker.send_packet('cpu,cpu=cpu0,host=fury usage_system=2.04,usage_user=5.40 1574753954000000000', 4711::text);
+SELECT pg_sleep(1) FROM db_worker.launch_udp_worker('db_worker', 4711::text);
+CALL db_worker.send_udp_packet('cpu,cpu=cpu0,host=fury usage_system=2.04,usage_user=5.40 1574753954000000000', 4711::text);
 SELECT pg_sleep(1);
 SELECT * FROM db_worker.cpu;
 ALTER TABLE db_worker.cpu ADD COLUMN cpu text;
-CALL db_worker.send_packet('cpu,cpu=cpu0,host=fury usage_system=2.04,usage_user=5.40 1574753955000000000', 4711::text);
+CALL db_worker.send_udp_packet('cpu,cpu=cpu0,host=fury usage_system=2.04,usage_user=5.40 1574753955000000000', 4711::text);
 SELECT pg_sleep(1);
 SELECT * FROM db_worker.cpu;
 ALTER TABLE db_worker.cpu ADD COLUMN host text;
-CALL db_worker.send_packet('cpu,cpu=cpu0,host=fury usage_system=2.04,usage_user=5.40 1574753956000000000', 4711::text);
+CALL db_worker.send_udp_packet('cpu,cpu=cpu0,host=fury usage_system=2.04,usage_user=5.40 1574753956000000000', 4711::text);
 SELECT pg_sleep(1);
 SELECT * FROM db_worker.cpu;
 SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE backend_type like '%Influx%';

--- a/sql/worker.sql
+++ b/sql/worker.sql
@@ -6,14 +6,14 @@ CREATE EXTENSION influx WITH SCHEMA db_worker;
 
 \set VERBOSITY terse
 \x on
-SELECT pg_sleep(1), pid AS worker_pid FROM db_worker.worker_launch('db_worker', 4711::text) AS pid \gset
-CALL db_worker.send_packet('cpu,cpu=cpu0,host=fury usage_system=2.0408163264927324,usage_user=2.0408163264927324 1574753954000000000', 4711::text);
-CALL db_worker.send_packet('cpu,cpu=cpu1,host=fury usage_system=3.921568627286635,usage_user=3.9215686274649673 1574753954000000000', 4711::text);
-CALL db_worker.send_packet('disk,device=nvme0n1p2,fstype=ext4,host=fury,mode=rw,path=/ free=912578965504i,total=1006530654208i,used=42751348736i,used_percent=4.475033200428718 1574753954000000000', 4711::text);
-CALL db_worker.send_packet('disk,device=nvme0n1p1,fstype=vfat,host=fury,mode=rw,path=/boot/efi free=527806464i,total=535805952i,used=7999488i,used_percent=1.4929822952022749 1574753954000000000', 4711::text);
-CALL db_worker.send_packet('system,host=fury load1=2.13,load15=0.84,load5=1.18,n_cpus=8i,n_users=1i 1574753954000000000', 4711::text);
-CALL db_worker.send_packet('system,host=fury uptime=607641i 1574753954000000000', 4711::text);
-CALL db_worker.send_packet('system,host=fury uptime_format="7 days,  0:47" 1574753954000000000', 4711::text);
+SELECT pg_sleep(1), pid AS worker_pid FROM db_worker.launch_udp_worker('db_worker', 4711::text) AS pid \gset
+CALL db_worker.send_udp_packet('cpu,cpu=cpu0,host=fury usage_system=2.0408163264927324,usage_user=2.0408163264927324 1574753954000000000', 4711::text);
+CALL db_worker.send_udp_packet('cpu,cpu=cpu1,host=fury usage_system=3.921568627286635,usage_user=3.9215686274649673 1574753954000000000', 4711::text);
+CALL db_worker.send_udp_packet('disk,device=nvme0n1p2,fstype=ext4,host=fury,mode=rw,path=/ free=912578965504i,total=1006530654208i,used=42751348736i,used_percent=4.475033200428718 1574753954000000000', 4711::text);
+CALL db_worker.send_udp_packet('disk,device=nvme0n1p1,fstype=vfat,host=fury,mode=rw,path=/boot/efi free=527806464i,total=535805952i,used=7999488i,used_percent=1.4929822952022749 1574753954000000000', 4711::text);
+CALL db_worker.send_udp_packet('system,host=fury load1=2.13,load15=0.84,load5=1.18,n_cpus=8i,n_users=1i 1574753954000000000', 4711::text);
+CALL db_worker.send_udp_packet('system,host=fury uptime=607641i 1574753954000000000', 4711::text);
+CALL db_worker.send_udp_packet('system,host=fury uptime_format="7 days,  0:47" 1574753954000000000', 4711::text);
 SELECT pg_sleep(2);
 
 SELECT * FROM db_worker.cpu;	--Automatically created
@@ -22,7 +22,7 @@ SELECT * FROM db_worker.system;
 
 SELECT count(*) FROM pg_stat_activity WHERE pid = :worker_pid;
 -- Syntax error, but the worker should not stop
-CALL db_worker.send_packet('system,host=fury', 4711::text);
+CALL db_worker.send_udp_packet('system,host=fury', 4711::text);
 SELECT pg_sleep(1);
 SELECT count(*) FROM pg_stat_activity WHERE pid = :worker_pid;
 

--- a/udp.c
+++ b/udp.c
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2022 Timescale Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "udp.h"
+
+#include <postgres.h>
+#include <fmgr.h>
+
+#include <commands/dbcommands.h>
+#include <executor/spi.h>
+#include <pgstat.h>
+#include <postmaster/bgworker.h>
+#include <storage/ipc.h>
+#include <storage/latch.h>
+#include <utils/builtins.h>
+#include <utils/elog.h>
+#include <utils/guc.h>
+#include <utils/lsyscache.h>
+#include <utils/snapmgr.h>
+
+#include "guc.h"
+#include "network.h"
+
+PG_FUNCTION_INFO_V1(launch_udp_worker);
+
+void StartUdpBackgroundWorkers(WorkerArgs *args) {
+  BackgroundWorker worker;
+  int i;
+
+  elog(LOG, "starting Influx UDP workers");
+
+  InfluxUdpWorkerInit(&worker, args);
+  elog(LOG, "memory allocated in %s memory context",
+       CurrentMemoryContext->name);
+  for (i = 0; i < InfluxWorkersCount; i++)
+    RegisterBackgroundWorker(&worker);
+
+  elog(LOG, "started Influx UDP workers");
+}
+
+/**
+ * Initalize a UDP worker before registering it.
+ */
+void InfluxUdpWorkerInit(BackgroundWorker *worker, WorkerArgs *args) {
+  memset(worker, 0, sizeof(*worker));
+  /* Shared memory access is necessary to connect to the database. */
+  worker->bgw_flags =
+      BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION;
+  worker->bgw_start_time = BgWorkerStart_RecoveryFinished;
+  worker->bgw_restart_time = BGW_NEVER_RESTART;
+  sprintf(worker->bgw_library_name, INFLUX_LIBRARY_NAME);
+  sprintf(worker->bgw_function_name, INFLUX_UDP_FUNCTION_NAME);
+  snprintf(worker->bgw_name, BGW_MAXLEN, "Influx UDP listener for schema %s",
+           args->namespace);
+  snprintf(worker->bgw_type, BGW_MAXLEN, "Influx UDP line protocol listener");
+  memcpy(worker->bgw_extra, args, sizeof(*args));
+}
+
+/**
+ * Main UDP worker function.
+ *
+ * The worker will read from a socket and write to a tables in a the
+ * given schema.
+ *
+ * From `MyBgworkerEntry` we expect the following fields to be set up:
+ *
+ * - Field `bgw_extra` will contain the worker arguments in a
+ *   WorkerArgs structure.
+ *
+ * - The database identifier is passed as a parameter to this
+ *   function.
+ */
+void InfluxUdpWorkerMain(Datum dbid) {
+  int sfd;
+  char buffer[INFLUX_MTU];
+  WorkerArgs *args = (WorkerArgs *)&MyBgworkerEntry->bgw_extra;
+  struct sockaddr_storage sockaddr;
+
+  InfluxWorkerSetup(args);
+
+  sfd = CreateSocket(NULL, args->service, &UdpRecvSocket,
+                     (struct sockaddr *)&sockaddr, sizeof(sockaddr));
+  if (sfd == -1) {
+    ereport(LOG, (errcode_for_socket_access(),
+                  errmsg("could not create socket for service '%s': %m",
+                         args->service)));
+    proc_exit(1);
+  }
+
+  ereport(
+      LOG,
+      (errmsg("worker listening on port %d",
+              SocketPort((struct sockaddr *)&sockaddr, sizeof(sockaddr))),
+       errdetail(
+           "Connected to database %s as user %s. Metrics written to schema %s.",
+           args->database, args->role, args->namespace)));
+
+  pgstat_report_activity(STATE_RUNNING, "reading events");
+
+  /* This is the same approach as used in pgstats.c: We read the
+     packets in two loops. One outer that will block when there is no
+     data received, and one inner loop that will read packets as long
+     as possible in non-blocking mode. */
+  while (true) {
+    int wait_result;
+    int err;
+
+    ResetLatch(MyLatch);
+    if (ShutdownWorker)
+      break;
+
+    /* We start a transaction to insert all packets that we're
+       reading. This is not optimal if we are constantly inserting
+       data since we will build a very large snapshot, but it is good
+       enough for a first implementation.
+
+       We need to open a non-atomic (that is, transactional) context
+       since we are opening a table for the metric and we need to make
+       sure that it does not change while we are updating it. */
+    if ((err = SPI_connect_ext(SPI_OPT_NONATOMIC)) != SPI_OK_CONNECT)
+      elog(ERROR, "SPI_connect failed: %s", SPI_result_code_string(err));
+    PushActiveSnapshot(GetTransactionSnapshot());
+
+    pgstat_report_activity(STATE_RUNNING, "processing incoming packets");
+
+    while (!ShutdownWorker) {
+      int bytes;
+
+      if (ReloadConfig) {
+        ReloadConfig = false;
+        ProcessConfigFile(PGC_SIGHUP);
+        elog(LOG, "configuration file reloaded");
+      }
+
+      /* Try to read one batch of rows from the socket. Note that the
+         socket is in noblock mode, so this might fail immediately and
+         we will then exit to the outer loop. */
+      bytes = recv(sfd, &buffer, sizeof(buffer), 0);
+      if (bytes < 0) {
+        /* Leave the inner loop if there either was no data to receive
+         * or if the call was interrupted by a signal. */
+        if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR)
+          break;
+        ereport(ERROR, (errcode_for_socket_access(),
+                        errmsg("could not read lines: %m")));
+      }
+
+      InfluxProcessPacket(buffer, bytes);
+    }
+
+    PopActiveSnapshot();
+    SPI_commit();
+    if ((err = SPI_finish()) != SPI_OK_FINISH)
+      elog(ERROR, "SPI_finish failed: %s", SPI_result_code_string(err));
+    pgstat_report_stat(false);
+    pgstat_report_activity(STATE_IDLE, NULL);
+
+    /* Here we block and wait until there is anything to read from the socket,
+     * or the postmaster shuts down. */
+    wait_result = WaitLatchOrSocket(
+        MyLatch, WL_LATCH_SET | WL_POSTMASTER_DEATH | WL_SOCKET_READABLE, sfd,
+        -1L, PG_WAIT_EXTENSION);
+    if (wait_result & WL_POSTMASTER_DEATH)
+      break; /* Abort the worker */
+  }
+
+  proc_exit(0);
+}
+
+/**
+ * Dynamically launch a UDP worker.
+ *
+ * This is used to start a UDP worker in, for example, tests. The
+ * worker is automatically associated with the current database.
+ *
+ * @param schema Schema name where tables for metrics are stored.
+ */
+Datum launch_udp_worker(PG_FUNCTION_ARGS) {
+  Oid nspid = PG_NARGS() == 1 ? get_func_namespace(fcinfo->flinfo->fn_oid)
+                              : PG_GETARG_OID(0);
+  char *service = text_to_cstring(PG_GETARG_TEXT_P(PG_NARGS() == 1 ? 0 : 1));
+  BackgroundWorker worker;
+  BackgroundWorkerHandle *handle;
+  BgwHandleStatus status;
+  pid_t pid;
+  WorkerArgs args = {0};
+
+  /* Check that we have a valid namespace id */
+  if (get_namespace_name(nspid) == NULL)
+    ereport(ERROR, (errcode(ERRCODE_UNDEFINED_SCHEMA),
+                    errmsg("schema with OID %d does not exist", nspid)));
+
+  strncpy(args.role, GetUserNameFromId(GetUserId(), true), sizeof(args.role));
+  strncpy(args.service, service, sizeof(args.service));
+  strncpy(args.namespace, get_namespace_name(nspid), sizeof(args.namespace));
+  strncpy(args.database, get_database_name(MyDatabaseId),
+          sizeof(args.database));
+
+  InfluxUdpWorkerInit(&worker, &args);
+
+  /* set bgw_notify_pid so that we can use WaitForBackgroundWorkerStartup */
+  worker.bgw_notify_pid = MyProcPid;
+
+  if (!RegisterDynamicBackgroundWorker(&worker, &handle))
+    PG_RETURN_NULL();
+
+  /* TODO: This only waits for the worker process to actually
+     start. It would simplify testing significantly if we wait for it
+     to be ready to accept input on the port since we can then start
+     sending rows without fear of them being lost, but that requires
+     more work that it's worth right now. */
+  status = WaitForBackgroundWorkerStartup(handle, &pid);
+
+  if (status == BGWH_STOPPED)
+    ereport(ERROR,
+            (errcode(ERRCODE_INSUFFICIENT_RESOURCES),
+             errmsg("could not start background process"),
+             errhint("More details may be available in the server log.")));
+
+  if (status == BGWH_POSTMASTER_DIED)
+    ereport(ERROR,
+            (errcode(ERRCODE_INSUFFICIENT_RESOURCES),
+             errmsg("cannot start background processes without postmaster"),
+             errhint("Kill all remaining database processes and restart the "
+                     "database.")));
+
+  ereport(LOG, (errmsg("background worker started"), errdetail("pid=%d", pid)));
+
+  Assert(status == BGWH_STARTED);
+  PG_RETURN_INT32(pid);
+}

--- a/udp.h
+++ b/udp.h
@@ -1,0 +1,15 @@
+#ifndef UDP_H_
+#define UDP_H_
+
+#include <postgres.h>
+
+#include "worker.h"
+
+#define INFLUX_UDP_FUNCTION_NAME "InfluxUdpWorkerMain"
+
+void InfluxUdpWorkerInit(BackgroundWorker *worker, WorkerArgs *args);
+void StartUdpBackgroundWorkers(WorkerArgs *args);
+
+void PGDLLEXPORT InfluxUdpWorkerMain(Datum dbid) pg_attribute_noreturn();
+
+#endif /* UDP_H_ */

--- a/worker.c
+++ b/worker.c
@@ -17,55 +17,43 @@
 #include "worker.h"
 
 #include <postgres.h>
-#include <fmgr.h>
 
-#include <access/table.h>
 #include <access/xact.h>
 #include <catalog/namespace.h>
-#include <commands/dbcommands.h>
-#include <executor/spi.h>
-#include <funcapi.h>
-#include <miscadmin.h>
 #include <pgstat.h>
-#include <postmaster/bgworker.h>
-#include <storage/ipc.h>
 #include <storage/latch.h>
-#include <utils/builtins.h>
 #include <utils/elog.h>
-#include <utils/guc.h>
 #if PG_VERSION_NUM < 150000
 #include <utils/int8.h>
 #endif
-#include <utils/jsonb.h>
-#include <utils/lsyscache.h>
-#include <utils/rel.h>
-#include <utils/snapmgr.h>
 
-#include <errno.h>
 #include <stdbool.h>
 #include <string.h>
 #include <unistd.h>
 
 #include "cache.h"
 #include "influx.h"
-#include "network.h"
 
-PG_FUNCTION_INFO_V1(worker_launch);
+volatile sig_atomic_t ReloadConfig = false;
+volatile sig_atomic_t ShutdownWorker = false;
 
-/* MTU for the wireless interface. We don't bother about digging up
- * the actual MTU here and just pick something that is common. */
-#define MTU 1500
-
-static volatile sig_atomic_t ReloadConfig = false;
-static volatile sig_atomic_t ShutdownWorker = false;
+/**
+ * Namespace OID for schema to write metrics to. This is shared by all
+ * kinds of protocols.
+ */
+Oid NamespaceOid;
 
 /* Check that sizeof(WorkerArgs) > BGW_EXTRALEN */
 static char c1[BGW_EXTRALEN - sizeof(WorkerArgs)] pg_attribute_unused();
 
 /**
  * Process one packet of lines.
+ *
+ * The packet consists of zero or more lines of Influx line protocol
+ * lines. These will be read and inserted into the database under the
+ * apropriate metric.
  */
-static void ProcessPacket(char *buffer, size_t bytes, Oid nspid) {
+void InfluxProcessPacket(char *buffer, size_t bytes) {
   IngestState *state;
 
   buffer[bytes] = '\0';
@@ -80,7 +68,7 @@ static void ProcessPacket(char *buffer, size_t bytes, Oid nspid) {
     PG_END_TRY();
     if (!result)
       return;
-    MetricInsert(&state->metric, nspid);
+    MetricInsert(&state->metric);
   }
 }
 
@@ -100,45 +88,7 @@ static void WorkerSighup(SIGNAL_ARGS) {
   errno = save_errno;
 }
 
-/**
- * Initalize a worker before registering it.
- */
-void InfluxWorkerInit(BackgroundWorker *worker, WorkerArgs *args) {
-  memset(worker, 0, sizeof(*worker));
-  /* Shared memory access is necessary to connect to the database. */
-  worker->bgw_flags =
-      BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION;
-  worker->bgw_start_time = BgWorkerStart_RecoveryFinished;
-  worker->bgw_restart_time = BGW_NEVER_RESTART;
-  sprintf(worker->bgw_library_name, INFLUX_LIBRARY_NAME);
-  sprintf(worker->bgw_function_name, INFLUX_FUNCTION_NAME);
-  snprintf(worker->bgw_name, BGW_MAXLEN, "Influx listener for schema %s",
-           args->namespace);
-  snprintf(worker->bgw_type, BGW_MAXLEN, "Influx line protocol listener");
-  memcpy(worker->bgw_extra, args, sizeof(*args));
-}
-
-/**
- * Main worker function.
- *
- * The worker will read from a socket and write to a tables in a the
- * given schema.
- *
- * From `MyBgworkerEntry` we expect the following fields to be set up:
- *
- * - Field `bgw_extra` will contain the worker arguments in a
- *   WorkerArgs structure.
- *
- * - The database identifier is passed as a parameter to this
- *   function.
- */
-void InfluxWorkerMain(Datum arg) {
-  int sfd;
-  char buffer[MTU];
-  WorkerArgs *args = (WorkerArgs *)&MyBgworkerEntry->bgw_extra;
-  Oid namespace_id;
-  struct sockaddr_storage sockaddr;
-
+void InfluxWorkerSetup(WorkerArgs *args) {
   /* Establish signal handlers; once that's done, unblock signals. */
   pqsignal(SIGTERM, WorkerSigterm);
   pqsignal(SIGHUP, WorkerSighup);
@@ -149,15 +99,6 @@ void InfluxWorkerMain(Datum arg) {
 
   CacheInit();
 
-  sfd = CreateSocket(NULL, args->service, &UdpRecvSocket,
-                     (struct sockaddr *)&sockaddr, sizeof(sockaddr));
-  if (sfd == -1) {
-    ereport(LOG, (errcode_for_socket_access(),
-                  errmsg("could not create socket for service '%s': %m",
-                         args->service)));
-    proc_exit(1);
-  }
-
   /* We need to start a transaction first because none is started and
      SPI_connect_ext might use TopTransactionContext, which is set by
      this function. The SPI_commit below will automatically start a
@@ -167,147 +108,5 @@ void InfluxWorkerMain(Datum arg) {
   /* It is necessary to start a transaction before calling functions
      like `get_namespace_oid`. Calling them before this will cause a
      crash. */
-  namespace_id = get_namespace_oid(args->namespace, false);
-
-  ereport(
-      LOG,
-      (errmsg("worker listening on port %d",
-              SocketPort((struct sockaddr *)&sockaddr, sizeof(sockaddr))),
-       errdetail(
-           "Connected to database %s as user %s. Metrics written to schema %s.",
-           args->database, args->role, args->namespace)));
-
-  pgstat_report_activity(STATE_RUNNING, "reading events");
-
-  /* This is the same approach as used in pgstats.c: We read the
-     packets in two loops. One outer that will block when there is no
-     data received, and one inner loop that will read packets as long
-     as possible in non-blocking mode. */
-  while (true) {
-    int wait_result;
-    int err;
-
-    ResetLatch(MyLatch);
-    if (ShutdownWorker)
-      break;
-
-    /* We start a transaction to insert all packets that we're
-       reading. This is not optimal if we are constantly inserting
-       data since we will build a very large snapshot, but it is good
-       enough for a first implementation.
-
-       We need to open a non-atomic (that is, transactional) context
-       since we are opening a table for the metric and we need to make
-       sure that it does not change while we are updating it. */
-    if ((err = SPI_connect_ext(SPI_OPT_NONATOMIC)) != SPI_OK_CONNECT)
-      elog(ERROR, "SPI_connect failed: %s", SPI_result_code_string(err));
-    PushActiveSnapshot(GetTransactionSnapshot());
-
-    pgstat_report_activity(STATE_RUNNING, "processing incoming packets");
-
-    while (!ShutdownWorker) {
-      int bytes;
-
-      if (ReloadConfig) {
-        ReloadConfig = false;
-        ProcessConfigFile(PGC_SIGHUP);
-        elog(LOG, "configuration file reloaded");
-      }
-
-      /* Try to read one batch of rows from the socket. Note that the
-         socket is in noblock mode, so this might fail immediately and
-         we will then exit to the outer loop. */
-      bytes = recv(sfd, &buffer, sizeof(buffer), 0);
-      if (bytes < 0) {
-        /* Leave the inner loop if there either was no data to receive
-         * or if the call was interrupted by a signal. */
-        if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR)
-          break;
-        ereport(ERROR, (errcode_for_socket_access(),
-                        errmsg("could not read lines: %m")));
-      }
-
-      ProcessPacket(buffer, bytes, namespace_id);
-    }
-
-    PopActiveSnapshot();
-    SPI_commit();
-    if ((err = SPI_finish()) != SPI_OK_FINISH)
-      elog(ERROR, "SPI_finish failed: %s", SPI_result_code_string(err));
-    pgstat_report_stat(false);
-    pgstat_report_activity(STATE_IDLE, NULL);
-
-    /* Here we block and wait until there is anything to read from the socket,
-     * or the postmaster shuts down. */
-    wait_result = WaitLatchOrSocket(
-        MyLatch, WL_LATCH_SET | WL_POSTMASTER_DEATH | WL_SOCKET_READABLE, sfd,
-        -1L, PG_WAIT_EXTENSION);
-    if (wait_result & WL_POSTMASTER_DEATH)
-      break; /* Abort the worker */
-  }
-
-  proc_exit(0);
-}
-
-/**
- * Dynamically launch a worker.
- *
- * This is used to start a worker in, for example, tests. The worker
- * is automatically associated with the current database.
- *
- * @param schema Schema name where tables for metrics are stored.
- */
-Datum worker_launch(PG_FUNCTION_ARGS) {
-  Oid nspid = PG_NARGS() == 1 ? get_func_namespace(fcinfo->flinfo->fn_oid)
-                              : PG_GETARG_OID(0);
-  char *service = text_to_cstring(PG_GETARG_TEXT_P(PG_NARGS() == 1 ? 0 : 1));
-  BackgroundWorker worker;
-  BackgroundWorkerHandle *handle;
-  BgwHandleStatus status;
-  pid_t pid;
-  WorkerArgs args = {0};
-
-  /* Check that we have a valid namespace id */
-  if (get_namespace_name(nspid) == NULL)
-    ereport(ERROR, (errcode(ERRCODE_UNDEFINED_SCHEMA),
-                    errmsg("schema with OID %d does not exist", nspid)));
-
-  strncpy(args.role, GetUserNameFromId(GetUserId(), true), sizeof(args.role));
-  strncpy(args.service, service, sizeof(args.service));
-  strncpy(args.namespace, get_namespace_name(nspid), sizeof(args.namespace));
-  strncpy(args.database, get_database_name(MyDatabaseId),
-          sizeof(args.database));
-
-  InfluxWorkerInit(&worker, &args);
-
-  /* set bgw_notify_pid so that we can use WaitForBackgroundWorkerStartup */
-  worker.bgw_notify_pid = MyProcPid;
-
-  if (!RegisterDynamicBackgroundWorker(&worker, &handle))
-    PG_RETURN_NULL();
-
-  /* TODO: This only waits for the worker process to actually
-     start. It would simplify testing significantly if we wait for it
-     to be ready to accept input on the port since we can then start
-     sending rows without fear of them being lost, but that requires
-     more work that it's worth right now. */
-  status = WaitForBackgroundWorkerStartup(handle, &pid);
-
-  if (status == BGWH_STOPPED)
-    ereport(ERROR,
-            (errcode(ERRCODE_INSUFFICIENT_RESOURCES),
-             errmsg("could not start background process"),
-             errhint("More details may be available in the server log.")));
-
-  if (status == BGWH_POSTMASTER_DIED)
-    ereport(ERROR,
-            (errcode(ERRCODE_INSUFFICIENT_RESOURCES),
-             errmsg("cannot start background processes without postmaster"),
-             errhint("Kill all remaining database processes and restart the "
-                     "database.")));
-
-  ereport(LOG, (errmsg("background worker started"), errdetail("pid=%d", pid)));
-
-  Assert(status == BGWH_STARTED);
-  PG_RETURN_INT32(pid);
+  NamespaceOid = get_namespace_oid(args->namespace, false);
 }

--- a/worker.h
+++ b/worker.h
@@ -19,10 +19,14 @@
 
 #include <postgres.h>
 
+#include <funcapi.h>
+#include <miscadmin.h>
 #include <postmaster/bgworker.h>
 
 #define INFLUX_LIBRARY_NAME "influx"
-#define INFLUX_FUNCTION_NAME "InfluxWorkerMain"
+/* MTU for the wireless interface. We don't bother about digging up
+ * the actual MTU here and just pick something that is common. */
+#define INFLUX_MTU 1500
 
 typedef struct WorkerArgs {
   char role[32];
@@ -34,5 +38,15 @@ typedef struct WorkerArgs {
 void InfluxWorkerInit(BackgroundWorker *worker, WorkerArgs *args);
 
 void PGDLLEXPORT InfluxWorkerMain(Datum dbid) pg_attribute_noreturn();
+
+void InfluxWorkerSetup(WorkerArgs *args);
+void InfluxProcessPacket(char *buffer, size_t bytes);
+
+/*
+ * Variables that are shared between all workers.
+ */
+extern volatile sig_atomic_t ReloadConfig;
+extern volatile sig_atomic_t ShutdownWorker;
+extern Oid NamespaceOid;
 
 #endif /* WORKER_H_ */


### PR DESCRIPTION
In preparation to support multiple different protocols we move the UDP-specific
pieces of code to a separate module and keep generic worker code in the worker
module. We also rename some functions to reflect that we will have different
protocols.

BREAKING CHANGE: `worker_launch` is renamed to `launch_udp_worker` and
`send_packet` is renamed to `send_udp_packet`.
