### PR TITLE
docs: use correct schema for metrics

### DIFF
--- a/docs/procedures.md
+++ b/docs/procedures.md
@@ -131,7 +131,7 @@ TABLE`:
 
 ```sql
 ALTER EXTENSION influx DROP FUNCTION metric._create;
-DROP FUNCTION db_create._create;
+DROP FUNCTION metric._create;
 ```
 
 To use a function that creates a table that just creates the `_fields`
@@ -141,8 +141,8 @@ column as a JSON (not JSONB) you can use the following definition:
 CREATE OR REPLACE FUNCTION metrics._create(metric name, tags name[], fields name[])
 RETURNS regclass AS $$
 BEGIN
-   EXECUTE format('CREATE TABLE db_create.%I (_time timestamp, _fields json)', metric);
-   RETURN format('db_create.%I', metric)::regclass;
+   EXECUTE format('CREATE TABLE metric.%I (_time timestamp, _fields json)', metric);
+   RETURN format('metric.%I', metric)::regclass;
 END;
 $$ LANGUAGE plpgsql;
 ```


### PR DESCRIPTION
There is a mix of using `metric` and `db_schema` in the example, but we should consistently use `metric` since that is the example schema for our metrics.