### PR TITLE
ci: build and test with PostgreSQL 16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [13, 14, 15]
+        version: [13, 14, 15, 16]
     container:
       image: postgres:${{ matrix.version }}
     steps:

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ sudo apt-get update
 sudo apt-get -y install postgresql postgresql-server-dev-13
 ```
 
+### Building from source
+
 After the dependencies are installed, you can download the repository
 from GitHub.
 
@@ -44,10 +46,7 @@ git clone git@github.com:mkindahl/pg_influx.git
 cd pg_influx
 ```
 
-### Building from source
-
-After the dependencies are installed, To build and install the
-extension:
+To build and install the extension:
 
 ```bash
 make
@@ -71,6 +70,15 @@ If you want to build unsigned packages, you can do that using
 
 ```bash
 debmake -t -i "debuild -i -uc -us"
+```
+
+### Adding PostgreSQL versions
+
+If a new version of PostgreSQL is supported, it is necessary to
+rebuild the `debian/control` file from the `debian/control.in` file.
+
+```bash
+pg_buildext updatecontrol
 ```
 
 ## Running Regression Tests

--- a/debian/control
+++ b/debian/control
@@ -36,3 +36,11 @@ Multi-Arch: foreign
 Depends: ${misc:Depends}, ${postgresql:Depends}, ${shlibs:Depends}
 Description: InfluxDB line protocol listener that can listen
  on UDP ports and insert into PostgreSQL database tables.
+
+Package: postgresql-16-pg-influx
+Section: database
+Architecture: any
+Multi-Arch: foreign
+Depends: ${misc:Depends}, ${postgresql:Depends}, ${shlibs:Depends}
+Description: InfluxDB line protocol listener that can listen
+ on UDP ports and insert into PostgreSQL database tables.

--- a/influx.c
+++ b/influx.c
@@ -41,7 +41,7 @@ PG_MODULE_MAGIC;
 
 PG_FUNCTION_INFO_V1(parse_influx);
 
-void _PG_init(void);
+void PGDLLEXPORT _PG_init(void);
 
 /** Number of Influx protocol workers. */
 static int InfluxWorkersCount;
@@ -141,7 +141,7 @@ Datum parse_influx(PG_FUNCTION_ARGS) {
   if (tuple == NULL)
     SRF_RETURN_DONE(funcctx);
 
-  SRF_RETURN_NEXT(funcctx, PointerGetDatum(HeapTupleGetDatum(tuple)));
+  SRF_RETURN_NEXT(funcctx, HeapTupleGetDatum(tuple));
 }
 
 static void StartBackgroundWorkers(const char *database_name,

--- a/worker.h
+++ b/worker.h
@@ -32,6 +32,7 @@ typedef struct WorkerArgs {
 } WorkerArgs;
 
 void InfluxWorkerInit(BackgroundWorker *worker, WorkerArgs *args);
-void InfluxWorkerMain(Datum dbid) pg_attribute_noreturn();
+
+void PGDLLEXPORT InfluxWorkerMain(Datum dbid) pg_attribute_noreturn();
 
 #endif /* WORKER_H_ */


### PR DESCRIPTION
Adding PGDLLEXPORT to symbols that need to be visible to PostgreSQL. For some
reason this did not fail in previous versions of PostgreSQL. Also, the
`debian/control` file is rebuilt to include PostgreSQL 16.
